### PR TITLE
Instance polling strategy per subscription

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -18,13 +18,13 @@ func Test_PollingStrategies(t *testing.T) {
 	}{
 		{
 			name:      "constant polling",
-			strategy:  ConstantPolling(time.Second),
+			strategy:  ConstantPolling(time.Second)(),
 			retrieved: []int64{0, 0, 1, 1},
 			delays:    []time.Duration{time.Second, time.Second, 0, 0},
 		},
 		{
 			name:      "exponential polling",
-			strategy:  ExpBackoffPolling(time.Second, 10*time.Second, 2),
+			strategy:  ExpBackoffPolling(time.Second, 10*time.Second, 2)(),
 			retrieved: []int64{1, 1, 0, 0, 0, 0, 0, 0},
 			delays:    []time.Duration{0, 0, time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 10 * time.Second, 10 * time.Second},
 		},


### PR DESCRIPTION
Currently a single polling strategy is shared by all subscriptions created by a client. This is an issue because polling strategies are not necessarily stateless, and a state change effected by one subscription will influence the polling strategy of another subscription.

This PR fixes this issue by introducing a default polling strategy factory in the client that producing a new polling strategy (with its own state) for each new subscription. There is also now the ability to override this default strategy per subscription using a subscription option func.