### PR TITLE
Implement dynamic polling

### DIFF
--- a/client.go
+++ b/client.go
@@ -338,6 +338,8 @@ func (c *Client) SubscribeToStream(
 				return
 			}
 
+			poll.Reset(cfg.pollingStrat(int64(len(msgs)), cfg.batchSize))
+
 			for _, msg := range msgs {
 				handleMessage(msg)
 			}
@@ -355,8 +357,6 @@ func (c *Client) SubscribeToStream(
 				live = false
 				handleLiveness(live)
 			}
-
-			poll.Reset(cfg.pollingStrat(int64(len(msgs)), cfg.batchSize))
 		}
 	}()
 
@@ -425,6 +425,8 @@ func (c *Client) SubscribeToCategory(
 				return
 			}
 
+			poll.Reset(cfg.pollingStrat(int64(len(msgs)), cfg.batchSize))
+
 			for _, msg := range msgs {
 				handleMessage(msg)
 			}
@@ -442,8 +444,6 @@ func (c *Client) SubscribeToCategory(
 				live = false
 				handleLiveness(live)
 			}
-
-			poll.Reset(cfg.pollingStrat(int64(len(msgs)), cfg.batchSize))
 		}
 	}()
 


### PR DESCRIPTION
Implements a dynamic polling strategy and fixes some general issues with how polling strategies are used.

* Start timer for next polling attempt before processing pending messages
* Implement a dynamic PollingStrategy that can dynamically adjust the polling delay based on a target read utilisation